### PR TITLE
feat: add VS Code installer and migrate zprofile PATH to home.sessionPath

### DIFF
--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -1,6 +1,10 @@
 # Avoid tmux pushing OSC 52 to the host terminal.
 set-option -s set-clipboard off
 
+# Let config/zsh/tmux-title.zsh own the window name via `rename-window`,
+# instead of tmux auto-renaming based on the foreground process.
+set-option -g automatic-rename off
+
 # Repeat window for pane resize bindings
 set-option -g repeat-time 1000
 

--- a/config/zsh/local.zsh
+++ b/config/zsh/local.zsh
@@ -1,0 +1,1 @@
+[ -f "$HOME/.zshrc.local" ] && source "$HOME/.zshrc.local"

--- a/config/zsh/tmux-title.zsh
+++ b/config/zsh/tmux-title.zsh
@@ -1,6 +1,8 @@
-# Track the last successfully-run command in the pane title so tmux #T
-# (used by catppuccin window tabs) shows what was last run instead of
-# the hostname. Failed commands do not stick.
+# Track the last successfully-run command in the tmux window name so the
+# tab shows what was last run instead of the auto-renamed process name.
+# Failed commands do not stick. Requires `automatic-rename off` in tmux.conf.
+[[ -z "$TMUX" ]] && return
+
 autoload -U add-zsh-hook
 
 typeset -g _tmux_title=""
@@ -8,7 +10,7 @@ typeset -g _tmux_pending=""
 
 _tmux_title_preexec() {
   _tmux_pending="${1%% *}"
-  print -Pn "\e]2;${_tmux_pending}\a"
+  tmux rename-window "$_tmux_pending"
 }
 add-zsh-hook preexec _tmux_title_preexec
 
@@ -16,13 +18,13 @@ _tmux_title_precmd() {
   local exit_status=$?
   if [[ -z "$_tmux_title" ]]; then
     _tmux_title="zsh"
-    print -Pn "\e]2;${_tmux_title}\a"
+    tmux rename-window "$_tmux_title"
   fi
   if [[ -n "$_tmux_pending" ]]; then
     if [[ $exit_status -eq 0 ]]; then
       _tmux_title="$_tmux_pending"
     else
-      print -Pn "\e]2;${_tmux_title}\a"
+      tmux rename-window "$_tmux_title"
     fi
     _tmux_pending=""
   fi

--- a/home-manager/home/shared.nix
+++ b/home-manager/home/shared.nix
@@ -8,6 +8,11 @@
     LANG = "en_US.UTF-8";
   };
 
+  home.sessionPath = [
+    "$HOME/bin"
+    "$HOME/.local/bin"
+  ];
+
   programs.git = {
     enable = true;
     settings = {
@@ -43,6 +48,7 @@
       ../../config/zsh/fzf.zsh
       ../../config/zsh/fnm.zsh
       ../../config/zsh/tmux-title.zsh
+      ../../config/zsh/local.zsh
     ]);
   };
 

--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -63,6 +63,15 @@ Tested on Ubuntu 26.04 (Wayland session).
 
 Log out and back in (or `newgrp docker`) for the docker group to take effect.
 
+### Visual Studio Code (system-level, not Nix-managed)
+
+```sh
+/path/to/dotfiles/ubuntu/scripts/install-vscode.sh
+```
+
+Updates flow through apt; run `sudo apt upgrade` (or enable unattended
+upgrades for `packages.microsoft.com`) to keep `code` current.
+
 ### First-time toolchain setup
 
 Some Nix packages provide a manager binary that needs an explicit toolchain install on first use:

--- a/ubuntu/scripts/install-vscode.sh
+++ b/ubuntu/scripts/install-vscode.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# Install Visual Studio Code on Ubuntu via Microsoft's apt repository.
+# System-level setup that home-manager cannot manage cleanly (GUI app
+# with frequent upstream releases); run once on a fresh machine.
+
+set -eux
+
+if command -v code >/dev/null 2>&1; then
+  echo "code already installed: $(code --version | head -n1)"
+  exit 0
+fi
+
+sudo apt update
+sudo apt install -y wget gpg apt-transport-https
+
+tmp_key="$(mktemp)"
+wget -qO- https://packages.microsoft.com/keys/microsoft.asc \
+  | gpg --dearmor > "$tmp_key"
+sudo install -D -o root -g root -m 644 "$tmp_key" \
+  /etc/apt/keyrings/packages.microsoft.gpg
+rm "$tmp_key"
+
+echo "deb [arch=amd64,arm64,armhf signed-by=/etc/apt/keyrings/packages.microsoft.gpg] https://packages.microsoft.com/repos/code stable main" \
+  | sudo tee /etc/apt/sources.list.d/vscode.list > /dev/null
+
+sudo apt update
+sudo apt install -y code
+
+cat <<'EOF'
+
+VS Code installed.
+
+Updates will arrive via `sudo apt upgrade`. To pull them in automatically,
+add `packages.microsoft.com` to Unattended-Upgrade::Allowed-Origins.
+EOF


### PR DESCRIPTION
## Summary
- Add `ubuntu/scripts/install-vscode.sh` to install VS Code via Microsoft's apt repository, idempotent and following the same `set -eux` style as `install-docker.sh`.
- Document the new script in `ubuntu/README.md` under Optional steps. Updates flow through `apt`, so no Nix-side changes are needed.
- Move `~/.zprofile`'s user-bin PATH additions into `home.sessionPath` so the same PATH applies to login, interactive, and script shells via the guarded `hm-session-vars.sh`.
- Source `~/.zshrc.local` at the end of `.zshrc` so per-machine shell tweaks can live outside the repo.

## Test plan
- [x] Run `sh -n ubuntu/scripts/install-vscode.sh` to syntax-check.
- [x] On a fresh Ubuntu machine without `code`, run `./ubuntu/scripts/install-vscode.sh` and confirm `code --version` works afterwards.
- [x] Re-run the script and confirm it short-circuits with the "code already installed" message.
- [ ] `sudo apt upgrade` picks up future VS Code releases.
- [x] `home-manager switch` succeeds and `$HOME/bin` / `$HOME/.local/bin` appear in PATH for a fresh shell.
- [x] `~/.zshrc.local` is sourced when present (verified via `[ -f ... ] && source` line in generated `.zshrc`).