### PR TITLE
feat: add sync.sh for routine pull and home-manager switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ See the per-host guide:
 
 After bootstrap, run the [first-time toolchain setup](./docs/toolchain-setup.md).
 
+## Sync
+
+For routine use, just run:
+
+```sh
+./scripts/sync.sh
+```
+
+This pulls the latest commits and applies them via `home-manager switch`. Idempotent — safe to run anytime.
+
 ## Updates
 
 See [UPDATES.md](./UPDATES.md).

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+dotfiles_dir="$(cd "$script_dir/.." && pwd)"
+
+git -C "$dotfiles_dir" pull --ff-only
+"$script_dir/setup-home-manager.sh"


### PR DESCRIPTION
## Summary
- Add `scripts/sync.sh` that runs `git pull --ff-only` then delegates to `setup-home-manager.sh`, so routine updates are a single idempotent command.
- Document it under a new `Sync` section in the top-level README to make it discoverable (previously the bootstrap script was only mentioned in per-host READMEs).

## Test plan
- [x] `./scripts/sync.sh` on Ubuntu host — pulls cleanly and runs `home-manager switch` to a successful activation.
- [ ] Verify on macOS host on next sync.