### PR TITLE
ci: auto-bump flake.lock twice a month

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,24 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    # 00:00 UTC on the 1st and 15th of every month (≈ bi-weekly, 09:00 JST)
+    - cron: "0 0 1,15 * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/update-flake-lock-action@main
+        with:
+          path-to-flake-dir: home-manager
+          pr-title: "chore: bump flake inputs"
+          pr-labels: dependencies

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -2,7 +2,7 @@ name: Update flake.lock
 
 on:
   schedule:
-    # 00:00 UTC on the 1st and 15th of every month (≈ bi-weekly, 09:00 JST)
+    # 00:00 UTC on the 1st and 15th of every month (≈ bi-weekly)
     - cron: "0 0 1,15 * *"
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Add a scheduled GitHub Actions workflow that runs `nix flake update` against `home-manager/` on the 1st and 15th of every month and opens (or refreshes) a PR with the new lock.
- Also runnable on demand via `workflow_dispatch`.

## Notes
- Uses `DeterminateSystems/update-flake-lock-action`, which force-pushes to a fixed branch, so at most one open "bump flake inputs" PR exists at a time.
- Requires the repo setting **Settings → Actions → General → Allow GitHub Actions to create and approve pull requests** to be enabled (one-time UI toggle).
- The action does not build/verify the result — the PR is a "please try this" notification, not a guarantee.

## Test plan
- [ ] Enable the repo setting above.
- [ ] After merge, trigger via Actions tab → "Update flake.lock" → Run workflow, and confirm a PR is opened against `master`.