### PR TITLE
ci: fix update-flake-lock action repo name

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: DeterminateSystems/update-flake-lock-action@main
+      - uses: DeterminateSystems/update-flake-lock@main
         with:
           path-to-flake-dir: home-manager
           pr-title: "chore: bump flake inputs"


### PR DESCRIPTION
## Summary
Initial workflow referenced `DeterminateSystems/update-flake-lock-action`, which 404s. The actual repo is `DeterminateSystems/update-flake-lock` (no `-action` suffix). Verified by dispatching the workflow on this branch via `gh workflow run --ref ci/fix-action-name`: run completed successfully in 39s and opened #18.