### PR TITLE
feat: auto-accept flake bump PRs in sync.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For routine use, just run:
 ./scripts/sync.sh
 ```
 
-This pulls the latest commits and applies them via `home-manager switch`. Idempotent — safe to run anytime.
+Pulls the latest commits and applies them via `home-manager switch`. If a pending flake bump PR (auto-opened by the [`update-flake-lock` workflow](./.github/workflows/update-flake-lock.yml)) is found, it is verified, merged, and applied as part of the same run. Idempotent — safe to run anytime.
 
 ## Updates
 

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -1,0 +1,10 @@
+# Prints the home-manager configuration name for the current OS to stdout,
+# or returns non-zero on an unsupported OS. Source this file and capture with:
+#   host=$(detect_host) || exit 1
+detect_host() {
+  case "$(uname -s)" in
+    Darwin) echo "x7c1@macos" ;;
+    Linux)  echo "x7c1@ubuntu" ;;
+    *) echo "Error: unsupported OS: $(uname -s)" >&2; return 1 ;;
+  esac
+}

--- a/scripts/setup-home-manager.sh
+++ b/scripts/setup-home-manager.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dotfiles_dir="$(cd "$script_dir/.." && pwd)"
 
-case "$(uname -s)" in
-  Darwin) host="x7c1@macos" ;;
-  Linux)  host="x7c1@ubuntu" ;;
-  *) echo "Error: unsupported OS: $(uname -s)" >&2; exit 1 ;;
-esac
+. "$script_dir/lib/host.sh"
+host=$(detect_host) || exit 1
 
 target="$HOME/.config/home-manager"
 source_dir="$dotfiles_dir/home-manager"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -4,5 +4,21 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 dotfiles_dir="$(cd "$script_dir/.." && pwd)"
 
-git -C "$dotfiles_dir" pull --ff-only
+. "$script_dir/lib/host.sh"
+
+cd "$dotfiles_dir"
+
+if command -v gh >/dev/null 2>&1; then
+  pr_number=$(gh pr list --head update_flake_lock_action --state open --json number --jq '.[0].number // empty')
+  if [ -n "$pr_number" ]; then
+    echo "==> Pending flake bump PR #$pr_number found. Verifying..."
+    host=$(detect_host) || exit 1
+    gh pr checkout "$pr_number"
+    (cd home-manager && nix build ".#homeConfigurations.\"$host\".activationPackage" --no-link)
+    git checkout master
+    gh pr merge "$pr_number" --squash --delete-branch
+  fi
+fi
+
+git pull --ff-only
 "$script_dir/setup-home-manager.sh"


### PR DESCRIPTION
## Summary
- `sync.sh` now detects an open flake bump PR (head branch `update_flake_lock_action`), verifies it by building the home-manager activation package, squash-merges on success, and proceeds to the existing pull + `home-manager switch` steps. The bump-acceptance step is silently skipped if `gh` isn't installed or no PR is pending — so the script remains a single, idempotent "update this machine" entry point regardless of how the change was authored.
- Extract host detection into `scripts/lib/host.sh` as a `detect_host` function, reused by `sync.sh` and `setup-home-manager.sh`.

## Test plan
- [ ] On a machine with no pending PR: `./scripts/sync.sh` pulls and switches as before.
- [ ] On a machine with a pending bump PR: same command verifies the build, merges the PR, and then activates the new generation.