### PR TITLE
feat: set lazygit enlargedSideViewLocation to top

### DIFF
--- a/home-manager/home/shared.nix
+++ b/home-manager/home/shared.nix
@@ -25,7 +25,12 @@
     includes = [{ path = "~/.config/git/config.local"; }];
   };
 
-  programs.lazygit.enable = true;
+  programs.lazygit = {
+    enable = true;
+    settings = {
+      gui.enlargedSideViewLocation = "top";
+    };
+  };
 
   programs.gh.enable = true;
 


### PR DESCRIPTION
## Summary
- Stack the side panel and main panel vertically (top/bottom) in `lazygit log` (SCREEN_HALF mode)
- Plain `lazygit` keeps the default left/right layout

## Test plan
- [x] `home-manager switch` succeeds
- [x] `lazygit log` renders with top/bottom split
- [x] Plain `lazygit` still renders with left/right split