### PR TITLE
chore: follow default branch rename from master to main

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -15,7 +15,7 @@ if command -v gh >/dev/null 2>&1; then
     host=$(detect_host) || exit 1
     gh pr checkout "$pr_number"
     (cd home-manager && nix build ".#homeConfigurations.\"$host\".activationPackage" --no-link)
-    git checkout master
+    git checkout main
     gh pr merge "$pr_number" --squash --delete-branch
   fi
 fi


### PR DESCRIPTION
## Summary
- Update `git checkout master` to `git checkout main` in `scripts/sync.sh` to follow the default branch rename from `master` to `main`.

## Test plan
- [ ] Verify `scripts/sync.sh` runs without error when a flake bump PR is pending.