### PR TITLE
feat: add gnumake to home.packages

### DIFF
--- a/home-manager/home/shared.nix
+++ b/home-manager/home/shared.nix
@@ -150,6 +150,7 @@
     rustup
     fnm
     protobuf
+    gnumake
   ];
 
   home.activation.createZshrcLocal = lib.hm.dag.entryAfter [ "writeBoundary" ] ''


### PR DESCRIPTION
## Summary
- Add `gnumake` to `home.packages` in `home-manager/home/shared.nix` so that `make` is available on both Ubuntu and macOS hosts.

## Test plan
- [x] `home-manager switch` succeeds on Ubuntu host
- [x] `make --version` reports GNU Make 4.4.1 from `~/.nix-profile/bin/make`
- [x] Verify the same on macOS host