### PR TITLE
feat: add gcc to home.packages

### DIFF
--- a/home-manager/home/shared.nix
+++ b/home-manager/home/shared.nix
@@ -151,6 +151,7 @@
     fnm
     protobuf
     gnumake
+    gcc
   ];
 
   home.activation.createZshrcLocal = lib.hm.dag.entryAfter [ "writeBoundary" ] ''


### PR DESCRIPTION
## Summary
- Add `gcc` to `home.packages` in `home-manager/home/shared.nix` so `cc`, `gcc`, `g++`, `ld`, `ar`, etc. are on the user shell PATH.
- Previously `gcc` only existed under `programs.neovim.extraPackages`, which puts it on neovim's wrapped PATH but leaves the user shell without `cc`.

## Test plan
- [x] `home-manager switch` on Linux host
- [x] `which cc` resolves under `~/.nix-profile/bin`
- [x] `cc --version` runs